### PR TITLE
Contextual errors (don't merge)

### DIFF
--- a/perl/bin/gherkin-generate-ast
+++ b/perl/bin/gherkin-generate-ast
@@ -17,6 +17,8 @@ sub run {
 
     my $parser = Gherkin::Parser->new();
 
+    local $ENV{'GHERKIN_VERBOSE_EXCEPTIONS'} = 1;
+
     for my $file (@file_list) {
         my $base;
         $base = $json->encode( $parser->parse($file) );

--- a/perl/lib/Gherkin/AstBuilder.pm
+++ b/perl/lib/Gherkin/AstBuilder.pm
@@ -72,8 +72,9 @@ sub get_location {
         return $token->location;
     } else {
         return {
-            line   => $token->location->{'line'},
-            column => $column,
+            line    => $token->location->{'line'},
+            context => $token->location->{'context'},
+            column  => $column,
         };
     }
 }

--- a/perl/lib/Gherkin/Exceptions.pm
+++ b/perl/lib/Gherkin/Exceptions.pm
@@ -50,7 +50,7 @@ sub new {
 
 sub message {
     my $self = shift;
-    return $self->context_message;
+    return $self->context_message if $ENV{'GHERKIN_VERBOSE_EXCEPTIONS'};
     return sprintf( '(%i:%i): %s',
         $self->{'location'}->{'line'},
         $self->{'location'}->{'column'} || '0',

--- a/perl/lib/Gherkin/Exceptions.pm
+++ b/perl/lib/Gherkin/Exceptions.pm
@@ -7,8 +7,7 @@ use overload
   q{""}    => 'stringify',
   fallback => 1;
 
-sub stringify { my $self  = shift; $self->{'message'} . "\n" }
-sub message   { my $self  = shift; $self->{'message'} }
+sub stringify { my $self  = shift; $self->message . "\n" }
 sub throw     { my $class = shift; die $class->new(@_) }
 
 # Parent of single and composite exceptions
@@ -23,10 +22,12 @@ use base 'Gherkin::Exceptions::Parser';
 
 sub new {
     my $class = shift;
-    bless {
-        message => join "\n",
-        ( 'Parser errors:', map { $_->{'message'} } @_ )
-    }, $class;
+    bless { errors => [@_], }, $class;
+}
+
+sub message {
+    my $class = shift;
+    return ( join '', ( "Parser errors:\n", @{ $class->{'errors'} } ) );
 }
 
 sub throw { my $class = shift; die $class->new(@_) }
@@ -36,14 +37,79 @@ sub throw { my $class = shift; die $class->new(@_) }
 #
 package Gherkin::Exceptions::SingleParser;
 
+use List::Util qw/max/;
 use base 'Gherkin::Exceptions::Parser';
 
 sub new {
     my ( $class, $message, $location ) = @_;
     bless {
-        message => sprintf( '(%i:%i): %s',
-            $location->{'line'}, $location->{'column'} || '0', $message ),
+        location         => $location,
+        original_message => $message,
     }, $class;
+}
+
+sub message {
+    my $self = shift;
+    return $self->context_message;
+    return sprintf( '(%i:%i): %s',
+        $self->{'location'}->{'line'},
+        $self->{'location'}->{'column'} || '0',
+        $self->{'original_message'} );
+}
+
+sub context_message {
+    my $self = shift;
+
+    my $template = <<'ERROR';
+-- %s Error --
+
+%s
+  at [%s] line %d, column %d
+
+-- [%s] --
+
+%s
+--%s--
+ERROR
+
+    my ($error_class) = ( ref($self) =~ m/::([^:]+)$/g );
+
+    my $location = $self->{'location'};
+    my $context_line_number =
+      $location->{'line'} - @{ $location->{'context'}->{'before'} };
+
+    my $context_template = "% 4d| %s";
+
+    my $context_string = join '',
+      map { sprintf( $context_template, $context_line_number++, $_ ) }
+      @{ $location->{'context'}->{'before'} },
+      ( $location->{'context'}->{'current'} || '' );
+
+    # If we're EOF, might be missing a newline, which would make the next line
+    # a bit weird
+    $context_string .= "\n" unless $context_string =~ m/\n$/;
+
+    # Add a caret to show the column
+    $context_string .= ( ' ' x 4 ) .    # Line number indent
+      '+' .                             # Instead of the pipe delimiter
+      ( '-' x 1 ) .                     # Demonstrate fake leading space
+      ( ' ' x ( ( $location->{'column'} || 1 ) - 1 ) ) .    # Column indent
+      "^\n";                                                # The marker itself
+
+    $context_string .= join '',
+      map { sprintf( $context_template, $context_line_number++, $_ ) }
+      @{ $location->{'context'}->{'after'} };
+
+    return sprintf( $template,
+        $error_class,
+        $self->{'original_message'},
+        $location->{'filename'},
+        $location->{'line'},
+        ( $location->{'column'} || 0 ),
+        $location->{'filename'},
+        $context_string,
+        ( '-' x ( 4 + length( $location->{'filename'} ) ) ),
+    );
 }
 
 package Gherkin::Exceptions::NoSuchLanguage;

--- a/perl/lib/Gherkin/Pickles/Compiler.pm
+++ b/perl/lib/Gherkin/Pickles/Compiler.pm
@@ -9,6 +9,8 @@ sub compile {
     my ( $class, $feature, $path ) = @_;
     my @pickles;
 
+    $path = $feature->{'location'}->{'context'}->{'filename'}
+      unless defined $path;
     my $dialect          = $feature->{'language'};
     my $feature_tags     = $feature->{'tags'};
     my $background_steps = $class->_get_background_steps( $feature, $path );

--- a/perl/lib/Gherkin/TokenScanner.pm
+++ b/perl/lib/Gherkin/TokenScanner.pm
@@ -3,7 +3,8 @@ package Gherkin::TokenScanner;
 use strict;
 use warnings;
 
-use Class::XSAccessor accessors => [qw/fh line_number/];
+use Class::XSAccessor accessors =>
+  [qw/fh line_number line_history line_queue filename/];
 
 use IO::File;
 use IO::Scalar;
@@ -14,22 +15,31 @@ use Gherkin::Token;
 use Gherkin::TokenMatcher;
 
 sub new {
-    my ( $class, $path_or_str ) = @_;
+    my ( $class, $path_or_str, $filename ) = @_;
 
-    # Perl convention is that a string reference is the string itself, but that
-    # a straight string is a path
+    # Perl convention is that a string reference is the string itself, but
+    # that a straight string is a path
     my $fh;
+
     if ( ref $path_or_str eq 'SCALAR' ) {
         my $data = $path_or_str;
         $fh = new IO::Scalar \$path_or_str;
+        $filename ||= '(unknown)';
     } else {
         $fh = IO::File->new();
         $fh->open( $path_or_str, '<' )
           || croak "Can't open [$path_or_str] for reading";
         $fh->binmode(':utf8');
+        $filename ||= $path_or_str;
     }
 
-    return bless { fh => $fh, line_number => 0 }, $class;
+    return bless {
+        fh           => $fh,
+        filename     => $filename,
+        line_number  => 0,
+        line_history => [],
+        line_queue   => []
+    }, $class;
 }
 
 sub next_line {
@@ -40,17 +50,94 @@ sub next_line {
 sub read {
     my $self = shift;
     $self->next_line();
-    my $line = $self->fh->getline;
+
+    # Take the next line from the queue, or from the filehandle
+    my $line =
+      ( shift( @{ $self->line_queue } ) || $self->_line_from_filehandle );
+
+    # Add this line to the history
+    push( @{ $self->line_history }, $line );
     return Gherkin::Token->new(
         line => $line
         ? (
             Gherkin::Line->new(
-                { line_text => $line, line_number => $self->line_number }
+                {
+                    line_text   => $line,
+                    line_number => $self->line_number,
+                }
             )
           )
         : undef,
-        location => { line => $self->line_number }
+        location => {
+            line     => $self->line_number,
+            context  => $self->line_context,
+            filename => $self->filename
+        }
     );
+}
+
+sub _fill_queue {
+    my ( $self, $count ) = @_;
+    while (( @{ $self->line_queue } < $count )
+        && ( $count-- )
+        && ( defined( my $line = $self->_line_from_filehandle ) ) )
+    {
+        push( @{ $self->line_queue }, $line );
+    }
+}
+
+sub line_context {
+    my ( $self, $wanted_before, $wanted_after ) = @_;
+    $wanted_before = 2 unless defined $wanted_before;
+    $wanted_after  = 2 unless defined $wanted_after;
+
+    my $before = [];
+    my $after  = [];
+
+    # If we don't have enough lines in one direction, we'll get them from the
+    # other.
+    $self->_fill_queue( $before + $after );
+
+    # Set to the last item (which is the current line) - 1, and attempt to get
+    # the desired number of lines from `before`
+    my $before_cursor = $#{ $self->line_history } - 1;
+    while ( $before_cursor >= 0 && $wanted_before ) {
+        unshift( @$before, $self->line_history->[$before_cursor] );
+        $before_cursor--;
+        $wanted_before--;
+    }
+
+    # Add any items we couldn't get from `before` to `after`. For example, we're
+    # at line 1 already, so there are no before lines, and we want to show
+    # context from before.
+    $wanted_after += $wanted_before;
+    my $after_cursor = 0;
+    while ( $after_cursor <= $#{ $self->line_queue } && $wanted_after ) {
+        push( @$after, $self->line_queue->[$after_cursor] );
+        $after_cursor++;
+        $wanted_after--;
+    }
+
+    # Add any items we couldn't get from `after` to `before` again; for example
+    # we're at the end of the file, and there were no after lines to get, so we
+    # want all the context from before.
+    $wanted_before += $wanted_after;
+    while ( $before_cursor >= 0 && $wanted_before ) {
+        unshift( @$before, $self->line_history->[$before_cursor] );
+        $before_cursor--;
+        $wanted_before--;
+    }
+
+    return {
+        before  => $before,
+        current => $self->line_history->[-1],
+        after   => $after,
+    };
+}
+
+sub _line_from_filehandle {
+    my $self = shift;
+    return $self->fh->getline;
 }
 
 sub DESTROY {

--- a/testdata/bad/empty.feature.errors
+++ b/testdata/bad/empty.feature.errors
@@ -1,2 +1,14 @@
 Parser errors:
-(1:0): unexpected end of file, expected: #Language, #TagLine, #FeatureLine, #Comment, #Empty
+-- UnexpectedEOF Error --
+
+unexpected end of file, expected: #Language, #TagLine, #FeatureLine, #Comment, #Empty
+  at [../testdata/bad/empty.feature] line 1, column 0
+
+-- [../testdata/bad/empty.feature] --
+
+   1| 
+    +-^
+
+-------------------------------------
+
+

--- a/testdata/bad/incomplete_examples_table.feature.errors
+++ b/testdata/bad/incomplete_examples_table.feature.errors
@@ -1,2 +1,18 @@
 Parser errors:
-(8:0): unexpected end of file, expected: #TableRow, #Comment, #Empty
+-- UnexpectedEOF Error --
+
+unexpected end of file, expected: #TableRow, #Comment, #Empty
+  at [../testdata/bad/incomplete_examples_table.feature] line 8, column 0
+
+-- [../testdata/bad/incomplete_examples_table.feature] --
+
+   4|     Given the <what>
+   5| 
+   6|   Examples:
+   7|     | what |
+   8| 
+    +-^
+
+---------------------------------------------------------
+
+

--- a/testdata/bad/inconsistent_cell_count.feature.errors
+++ b/testdata/bad/inconsistent_cell_count.feature.errors
@@ -1,3 +1,34 @@
 Parser errors:
-(6:7): inconsistent cell count within the table
-(14:5): inconsistent cell count within the table
+-- AstBuilder Error --
+
+inconsistent cell count within the table
+  at [../testdata/bad/inconsistent_cell_count.feature] line 6, column 7
+
+-- [../testdata/bad/inconsistent_cell_count.feature] --
+
+   4|     Given a data table with inconsistent cell count
+   5|       | foo | bar |
+   6|       | boz | 
+    +-      ^
+   7| 
+   8| 
+
+-------------------------------------------------------
+
+-- AstBuilder Error --
+
+inconsistent cell count within the table
+  at [../testdata/bad/inconsistent_cell_count.feature] line 14, column 5
+
+-- [../testdata/bad/inconsistent_cell_count.feature] --
+
+  10|     Given the <what>
+  11| 
+  12|   Examples: 
+  13|     | what       |
+  14|     | minimalism | extra |
+    +-    ^
+
+-------------------------------------------------------
+
+

--- a/testdata/bad/invalid_language.feature.errors
+++ b/testdata/bad/invalid_language.feature.errors
@@ -1,2 +1,18 @@
 Parser errors:
-(1:1): Language not supported: no-such
+-- NoSuchLanguage Error --
+
+Language not supported: no-such
+  at [../testdata/bad/invalid_language.feature] line 1, column 1
+
+-- [../testdata/bad/invalid_language.feature] --
+
+   1| #language:no-such
+    +-^
+   2| 
+   3| Feature: Minimal
+   4| 
+   5|   Scenario: minimalistic
+
+------------------------------------------------
+
+

--- a/testdata/bad/multiple_parser_errors.feature.errors
+++ b/testdata/bad/multiple_parser_errors.feature.errors
@@ -1,3 +1,34 @@
 Parser errors:
-(2:1): expected: #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'invalid line here'
-(9:1): expected: #EOF, #TableRow, #DocStringSeparator, #StepLine, #TagLine, #ScenarioLine, #ScenarioOutlineLine, #Comment, #Empty, got 'another invalid line here'
+-- UnexpectedToken Error --
+
+expected: #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'invalid line here'
+  at [../testdata/bad/multiple_parser_errors.feature] line 2, column 1
+
+-- [../testdata/bad/multiple_parser_errors.feature] --
+
+   1| 
+   2| invalid line here
+    +-^
+   3| 
+   4| Feature: Multiple parser errors
+   5| 
+
+------------------------------------------------------
+
+-- UnexpectedToken Error --
+
+expected: #EOF, #TableRow, #DocStringSeparator, #StepLine, #TagLine, #ScenarioLine, #ScenarioOutlineLine, #Comment, #Empty, got 'another invalid line here'
+  at [../testdata/bad/multiple_parser_errors.feature] line 9, column 1
+
+-- [../testdata/bad/multiple_parser_errors.feature] --
+
+   5| 
+   6|   Scenario: minimalistic
+   7|     Given the minimalism
+   8| 
+   9| another invalid line here
+    +-^
+
+------------------------------------------------------
+
+

--- a/testdata/bad/not_gherkin.feature.errors
+++ b/testdata/bad/not_gherkin.feature.errors
@@ -1,3 +1,29 @@
 Parser errors:
-(1:1): expected: #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'not gherkin'
-(3:0): unexpected end of file, expected: #Language, #TagLine, #FeatureLine, #Comment, #Empty
+-- UnexpectedToken Error --
+
+expected: #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'not gherkin'
+  at [../testdata/bad/not_gherkin.feature] line 1, column 1
+
+-- [../testdata/bad/not_gherkin.feature] --
+
+   1| not gherkin
+    +-^
+   2| 
+
+-------------------------------------------
+
+-- UnexpectedEOF Error --
+
+unexpected end of file, expected: #Language, #TagLine, #FeatureLine, #Comment, #Empty
+  at [../testdata/bad/not_gherkin.feature] line 3, column 0
+
+-- [../testdata/bad/not_gherkin.feature] --
+
+   1| not gherkin
+   2| 
+   3| 
+    +-^
+
+-------------------------------------------
+
+

--- a/testdata/bad/single_parser_error.feature.errors
+++ b/testdata/bad/single_parser_error.feature.errors
@@ -1,2 +1,18 @@
 Parser errors:
-(2:1): expected: #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'invalid line here'
+-- UnexpectedToken Error --
+
+expected: #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'invalid line here'
+  at [../testdata/bad/single_parser_error.feature] line 2, column 1
+
+-- [../testdata/bad/single_parser_error.feature] --
+
+   1| 
+   2| invalid line here
+    +-^
+   3| 
+   4| Feature: Single parser error
+   5| 
+
+---------------------------------------------------
+
+

--- a/testdata/bad/unexpected_eof.feature.errors
+++ b/testdata/bad/unexpected_eof.feature.errors
@@ -1,2 +1,18 @@
 Parser errors:
-(5:0): unexpected end of file, expected: #TableRow, #DocStringSeparator, #StepLine, #TagLine, #ExamplesLine, #Comment, #Empty
+-- UnexpectedEOF Error --
+
+unexpected end of file, expected: #TableRow, #DocStringSeparator, #StepLine, #TagLine, #ExamplesLine, #Comment, #Empty
+  at [../testdata/bad/unexpected_eof.feature] line 5, column 0
+
+-- [../testdata/bad/unexpected_eof.feature] --
+
+   1| Feature: Unexpected end of file
+   2| 
+   3|   Scenario Outline: minimalistic
+   4|     Given the minimalism
+   5| 
+    +-^
+
+----------------------------------------------
+
+


### PR DESCRIPTION
Adds contextual errors eg:

```
-- UnexpectedEOF Error --

unexpected end of file, expected: #TableRow, #DocStringSeparator, #StepLine, #TagLine, #ExamplesLine, #Comment, #Empty
  at [../testdata/bad/unexpected_eof.feature] line 5, column 0

-- [../testdata/bad/unexpected_eof.feature] --

   1| Feature: Unexpected end of file
   2| 
   3|   Scenario Outline: minimalistic
   4|     Given the minimalism
   5| 
    +-^

----------------------------------------------
```

```
-- UnexpectedToken Error --

expected: #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'invalid line here'
  at [placeholder] line 2, column 1

-- [placeholder] --

   1| 
   2| invalid line here
    +-^
   3| 
   4| Feature: Single parser error
   5| 

-------------------
```

Are these what we want? Should they be the default? Thoughts please...
