### PR TITLE
Pickle filters

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -45,6 +45,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>tag-expressions</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>

--- a/java/src/main/java/gherkin/pickles/PicklePredicate.java
+++ b/java/src/main/java/gherkin/pickles/PicklePredicate.java
@@ -1,0 +1,5 @@
+package gherkin.pickles;
+
+public interface PicklePredicate {
+    boolean test(Pickle pickle);
+}

--- a/java/src/main/java/gherkin/pickles/TagExpressionPredicate.java
+++ b/java/src/main/java/gherkin/pickles/TagExpressionPredicate.java
@@ -1,0 +1,24 @@
+package gherkin.pickles;
+
+import io.cucumber.tagexpressions.Expression;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TagExpressionPredicate implements PicklePredicate {
+    private final Expression tagExpression;
+
+    public TagExpressionPredicate(Expression tagExpression) {
+        this.tagExpression = tagExpression;
+    }
+
+    @Override
+    public boolean test(Pickle pickle) {
+        List<String> tagNames = new ArrayList<>();
+        List<PickleTag> tags = pickle.getTags();
+        for (PickleTag tag : tags) {
+            tagNames.add(tag.getName());
+        }
+        return tagExpression.evaluate(tagNames);
+    }
+}

--- a/java/src/test/java/gherkin/pickles/TagExpressionPredicateTest.java
+++ b/java/src/test/java/gherkin/pickles/TagExpressionPredicateTest.java
@@ -1,0 +1,48 @@
+package gherkin.pickles;
+
+import gherkin.AstBuilder;
+import gherkin.Parser;
+import gherkin.ast.GherkinDocument;
+import gherkin.deps.com.google.gson.Gson;
+import gherkin.deps.com.google.gson.GsonBuilder;
+import io.cucumber.tagexpressions.Expression;
+import io.cucumber.tagexpressions.TagExpressionParser;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class TagExpressionPredicateTest {
+    private final Parser<GherkinDocument> parser = new Parser<>(new AstBuilder());
+    private final Compiler compiler = new Compiler();
+    private Gson gson = new GsonBuilder().setPrettyPrinting().create();
+
+    @Test
+    public void compiles_a_scenario() throws IOException {
+        List<Pickle> pickles = compiler.compile(parser.parse("" +
+                "@grabme\n" +
+                "Feature: f\n" +
+                "  Scenario: s\n" +
+                "    Given passing\n" +
+                "  @metoo\n" +
+                "  Scenario: m\n" +
+                "    Given whatever\n"
+
+        ), "features/hello.feature");
+
+        Expression tagExpression = new TagExpressionParser().parse("@grabme and @metoo");
+        PicklePredicate predicate = new TagExpressionPredicate(tagExpression);
+        List<Pickle> filteredPickles = new ArrayList<>();
+        for (Pickle pickle : pickles) {
+            if(predicate.test(pickle)) {
+                filteredPickles.add(pickle);
+            }
+        }
+        assertEquals(1, filteredPickles.size());
+        assertEquals("m", filteredPickles.get(0).getName());
+    }
+
+}


### PR DESCRIPTION
I'm not 100% sure whether pickle filtering ought to live in the pickle library itself, or in Cucumber. I'm inclined to put it into pickles (which I'd like to extract to an independent [standard library](http://docs.cucumber.io/docs/standard-library.html)), because that would allow other libraries like Gherkin Lint to use it too. But maybe it's too early to say whether this is the [right abstraction](http://www.sandimetz.com/blog/2016/1/20/the-wrong-abstraction).

I'm proposing adding it here for now, for lack of a better place to put it. I only wrote it to get a feel for how the new [Tag Expressions](http://docs.cucumber.io/tag-expressions/) library feels to use, and it felt really simple! Ideally I'd put it in the Cucumber-JVM 2.x codebase, but that doesn't exist yet (except for a somewhat experimental design on my local machine).

Can we build other filters on this abstraction such as line filter and pattern filter? What about filtering scenarios based on other criteria such as error message? That would require a mechanism to attach metadata to pickles, perhaps during a Cucumber run. Would this be an acceptable design if we go for immutable data structures? Attaching metadata to a pickle would result in a new pickle being created, keeping the original unchanged.

Could we somehow align this metadata API with the [Cucumber Event Protocol](http://docs.cucumber.io/docs/architecture/event-protocol.html)?

Let me know what you think @cucumber/developers
