### PR TITLE
[Java] Add accessors for languages and dialect keywords.

### DIFF
--- a/java/src/main/java/gherkin/GherkinDialect.java
+++ b/java/src/main/java/gherkin/GherkinDialect.java
@@ -23,11 +23,11 @@ public class GherkinDialect {
 
     public List<String> getStepKeywords() {
         List<String> result = new ArrayList<>();
-        result.addAll(keywords.get("given"));
-        result.addAll(keywords.get("when"));
-        result.addAll(keywords.get("then"));
-        result.addAll(keywords.get("and"));
-        result.addAll(keywords.get("but"));
+        result.addAll(getGivenKeywords());
+        result.addAll(getWhenKeywords());
+        result.addAll(getThenKeywords());
+        result.addAll(getAndKeywords());
+        result.addAll(getButKeywords());
         return result;
     }
 
@@ -41,6 +41,26 @@ public class GherkinDialect {
 
     public List<String> getExamplesKeywords() {
         return keywords.get("examples");
+    }
+
+    public List<String> getGivenKeywords() {
+        return keywords.get("given");
+    }
+
+    public List<String> getWhenKeywords() {
+        return keywords.get("when");
+    }
+
+    public List<String> getThenKeywords() {
+        return keywords.get("then");
+    }
+
+    public List<String> getAndKeywords() {
+        return keywords.get("and");
+    }
+
+    public List<String> getButKeywords() {
+        return keywords.get("but");
     }
 
     public String getLanguage() {

--- a/java/src/main/java/gherkin/GherkinDialectProvider.java
+++ b/java/src/main/java/gherkin/GherkinDialectProvider.java
@@ -6,8 +6,12 @@ import gherkin.deps.com.google.gson.Gson;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import static java.util.Collections.sort;
+import static java.util.Collections.unmodifiableList;
 
 public class GherkinDialectProvider implements IGherkinDialectProvider {
     private static Map<String, Map<String, List<String>>> DIALECTS;
@@ -43,5 +47,12 @@ public class GherkinDialectProvider implements IGherkinDialectProvider {
         }
 
         return new GherkinDialect(language, map);
+    }
+
+    @Override
+    public List<String> getLanguages() {
+        List<String> languages = new ArrayList<String>(DIALECTS.keySet());
+        sort(languages);
+        return unmodifiableList(languages);
     }
 }

--- a/java/src/main/java/gherkin/IGherkinDialectProvider.java
+++ b/java/src/main/java/gherkin/IGherkinDialectProvider.java
@@ -2,8 +2,12 @@ package gherkin;
 
 import gherkin.ast.Location;
 
+import java.util.List;
+
 public interface IGherkinDialectProvider {
     GherkinDialect getDefaultDialect();
 
     GherkinDialect getDialect(String language, Location location);
+
+    List<String> getLanguages();
 }


### PR DESCRIPTION
To be able to implement the `--i18n` option in Cucumber-JVM, methods to fetch:
* the list of all available languages ([for the `--i18n help` option](https://github.com/cucumber/cucumber-jvm/blob/waiting-for-gherkin-fixes/core/src/main/java/cucumber/runtime/RuntimeOptions.java#L249-L255)), and 
* the list for each keyword for a specific language ([for the `--i18n <language>` option](https://github.com/cucumber/cucumber-jvm/blob/waiting-for-gherkin-fixes/core/src/main/java/cucumber/runtime/RuntimeOptions.java#L265-L286))

is needed.