### PR TITLE
Use latest coveralls for install error on Ruby 2.4.0

### DIFF
--- a/ruby/gherkin.gemspec
+++ b/ruby/gherkin.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec',     '~> 3.5'
 
   # For coverage reports
-  s.add_development_dependency 'coveralls', '~> 0.8.7', '< 0.8.8'
+  s.add_development_dependency 'coveralls', '~> 0.8.7', '< 0.8.18'
 
   s.rubygems_version = ">= 1.6.1"
   s.files            = `git ls-files`.split("\n").reject {|path| path =~ /\.gitignore$/ }


### PR DESCRIPTION
This pull-requst is to use latest version coveralls, because of `bundle install` error on Ruby 2.4.0.

```
$ ruby -v 
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]

$ bundle -v
Bundler version 1.13.7

$ bundle install --path vendor/bundle
...
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
/home/jaruga/git/gherkin/ruby/vendor/bundle/ruby/2.4.0/gems/json-1.8.3/ext/json/ext/generator
/usr/local/ruby-2.4.0/bin/ruby -r ./siteconf20170110-15974-k7ebd0.rb extconf.rb
creating Makefile

current directory:
/home/jaruga/git/gherkin/ruby/vendor/bundle/ruby/2.4.0/gems/json-1.8.3/ext/json/ext/generator
make "DESTDIR=" clean

current directory:
/home/jaruga/git/gherkin/ruby/vendor/bundle/ruby/2.4.0/gems/json-1.8.3/ext/json/ext/generator
make "DESTDIR="
compiling generator.c
generator.c: In function ‘generate_json’:
generator.c:861:25: error: ‘rb_cFixnum’ undeclared (first use in this function)
     } else if (klass == rb_cFixnum) {
                         ^~~~~~~~~~
generator.c:861:25: note: each undeclared identifier is reported only once for each
function it appears in
generator.c:863:25: error: ‘rb_cBignum’ undeclared (first use in this function)
     } else if (klass == rb_cBignum) {
                         ^~~~~~~~~~
generator.c: At top level:
cc1: warning: unrecognized command line option ‘-Wno-self-assign’
cc1: warning: unrecognized command line option ‘-Wno-constant-logical-operand’
cc1: warning: unrecognized command line option ‘-Wno-parentheses-equality’
Makefile:241: recipe for target 'generator.o' failed
make: *** [generator.o] Error 1

make failed, exit code 2
...
```

Get Gemfile.lock file to check the dependency.
And coveralls (0.8.7) depends on json (~> 1.8)

```
$ git clean -fdx
$ bundle lock
```
