### PR TITLE
Add Ruby 2.4.0 and ruby-head in .travis.yml.

### DIFF
--- a/ruby/.travis.yml
+++ b/ruby/.travis.yml
@@ -1,8 +1,14 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.3
+  - ruby-head
+  - 2.4.0
+  - 2.3
   - 2.2
   - 2.1
   - 2.0
   - jruby
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true


### PR DESCRIPTION
I want to add Ruby 2.4.0 and ruby-head to Travis.
The motivation and the detail is same with https://github.com/cucumber/cucumber-ruby/pull/1087
Thank you!
